### PR TITLE
Add devDependencies to the manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
   "scripts": {
     "test": "node test/test"
   },
+  "devDependencies": {
+    "array-findindex": "0.1.0",
+    "lodash.findindex": "3.2.0"
+  },
   "homepage": "https://github.com/jsdf/find-index",
   "bugs": "https://github.com/jsdf/find-index/issues",
   "repository": {


### PR DESCRIPTION
Hi,

here’s what I got when trying to run the tests:

``` bash
$ npm install && npm test

> find-index@0.1.1 test /home/tomekwi/Libraries/jsdf/find-index
> node test/test


module.js:340
    throw err;
          ^
Error: Cannot find module 'lodash.findindex'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/home/tomekwi/Libraries/jsdf/find-index/test/test.js:7:19)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
npm ERR! Test failed.  See above for more details.
npm ERR! not ok code 0
```

I’ve added the missing dependencies to the `package.json`. They’re `devDependencies` so they won’t get installed when you run `npm install find-index` – but only when you check out the whole project and run `npm install` in there.
