### PR TITLE
Include the native array.findIndex in the tests

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -8,6 +8,12 @@ cases['lodash'] = require('lodash.findindex');
 
 cases['array-findindex'] = require('array-findindex');
 
+if (typeof Array.prototype.findIndex === 'function') {
+  cases['array.findIndex'] = function (array, predicate, context) {
+    return array.findIndex(predicate, context);
+  };
+}
+
 // test setup
 var testNumValues = 1000;
 


### PR DESCRIPTION
Uses `array.prototype.findIndex` if it’s available.

In reference to #3.
